### PR TITLE
Eliminate relative path from build.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
             }
             steps {
                 sh "mvn deploy -P buildDockerImageOnJenkins -DdockerImage.tag=api-gateway-parent-develop.${env.BUILD_NUMBER} -Ddocker.registry=docker-dev-local.art.local -DdeleteDockerImages=true -DskipTests=true -DskipITs"
-		sh "cd ${WORKSPACE}/fru-paqx-distribution; docker/compose/build_rpm.sh"
+		sh "cd ${WORKSPACE}/fru-paqx-distribution; ${WORKSPACE}/fru-paqx-distribution/docker/compose/build_rpm.sh"
 		archiveArtifacts artifacts: '**/*.rpm', fingerprint: true
             }
         }


### PR DESCRIPTION
We are getting a permission denied error when attempting to build the rpm from the build_rpm.sh script. Possibly it doesn't work well with a relative path so we are giving it a full path to the script.

<!--
Complete these steps before submitting a pull request:
This section will not appear in the preview.

1. Fork the repository and create a new branch based on master
2. Ensure that your code has adequate test coverage for all new functionality
3. Make sure the test suite passes
4. Label the pull request where appropriate: bug, duplicate, enhancement, etc.
5. Submit your request with a short title and a clear explanation of the changes.

Please mark an [X] and fill in all items that relate to your issue:

-->

- [x] I have read the [CONTRIBUTION GUIDE][contributing]
- [x] This is a bug
- [ ] This is a feature request
- [ ] This is a syntax/style fix
- [ ] This is an improvement to code quality

---

Provide a clear description of changes:
 
[contributing]: http://dellemc-symphony.readthedocs.io/en/latest/contributingtosymphony.html